### PR TITLE
sandbox: allow ccache to be stored on same partition.

### DIFF
--- a/ui/build/sandbox_linux.go
+++ b/ui/build/sandbox_linux.go
@@ -235,6 +235,11 @@ func (c *Cmd) wrapSandbox() {
 		sandboxArgs = append(sandboxArgs, "-N")
 	}
 
+	if ccacheDir := os.Getenv("CCACHE_DIR"); ccacheDir != "" {
+		sandboxArgs = append(sandboxArgs, "-B", ccacheDir)
+	}
+
+
 	// Stop nsjail from parsing arguments
 	sandboxArgs = append(sandboxArgs, "--")
 


### PR DESCRIPTION
* I don't know why this was done exactly. Google just doesn't care about ccache

Signed-off-by: Matt Filetto <matt.filetto@gmail.com>